### PR TITLE
Requirements.txt file is invalid

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,3 @@
-- yaml (shipped due to incompatibility with 1.2 of both stable and #head)
-- terminaltables
-- zip/zipfiles
-
+yaml # (shipped due to incompatibility with 1.2 of both stable and #head)
+terminaltables
+zip

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,3 +1,3 @@
-yaml # (shipped due to incompatibility with 1.2 of both stable and #head)
+# yaml (shipped due to incompatibility with 1.2 of both stable and #head)
 terminaltables
 zip


### PR DESCRIPTION
Hi! I was looking at your repo and noticed that your requirements.txt file, which should enable:

```bash
$ pip install -r requirements.txt
```
is not in a valid format. Is this intentional? If it's not meant to be a python requirements file perhaps it should be named something else. I found it because I have a tool that looks for them and it choked on parsing this particular one. I wasn't sure what the comment meant with yaml, which is provided by python. If you are doing an import of yaml perhaps this should by pyaml or PyYaml?